### PR TITLE
Made getProductItems support v2 only

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,7 +47,13 @@ app.all('*', (req, res, next) => {
 
 // Response
 
-app.get('/', getProductItems)
+app.get('/', (req, res, next) => {
+  if (req.header('Version') === 'v2') {
+    getProductItems
+  } else {
+    next();
+  }
+});
 
 app.all('*', (req, res, next) => {
   if (req.header('Version') === 'v1') {


### PR DESCRIPTION
- v1 API request was hanging due to app.get not checking who was making the request. The app.get now only calls getProductItems if v2 is in header