### PR TITLE
Fetch manufacturer redis

### DIFF
--- a/api/fetch-manufacturer-availability.js
+++ b/api/fetch-manufacturer-availability.js
@@ -1,35 +1,65 @@
 const query = require('../db/index.js');
 const dotenv = require('dotenv');
 const fetch = require('node-fetch');
-const updateAvailability = require('../db/update-availability.js')
+const { promisify } = require("util");
 
-if (process.env.NODE_ENV !== 'production') {
-  dotenv.config();
-}
+if (process.env.NODE_ENV !== 'production') dotenv.config();
+
+// Init Redis
+const redis_url = process.env.REDIS_URL || null;
+const redis = require("redis");
+const client = redis.createClient(redis_url);
+const cacheTimer = process.env.CACHE_TIMER || 300;
+
+client.on("error", (error) => console.error(error));
+const getAsync = promisify(client.get).bind(client);
+
+// Get value from Redis that depends upon an async call
+const getResult = async (manufacturer) => {
+  try {
+    return await getAsync(manufacturer);
+  } catch (err) {
+    console.log(err);
+  };
+};
+
+// Get Manufacturer Availability
 
 const fetchManufacturerAvailability = async (manufacturer, product) => {
-  const url = `${process.env.MANUFACTURER_URL}${manufacturer}`; // Build URL
-  let data;
+  // // Check if Redis has data for the manufacturer
+  let result = JSON.parse(await getResult(manufacturer));
+  let resValue = {};
+  if (!result) {
+    // No manufacturer data in hash, fetch it
+    console.log('Fetching data for', product, manufacturer, result);
+    const url = `${process.env.MANUFACTURER_URL}${manufacturer}`; // Build URL
+    let data;
 
-  try {
-    // Try to get the data
-    const response = await fetch(url);
-    data = await response.json();
+    try {
+      // Try to get the data
+      const response = await fetch(url);
+      data = await response.json();
 
-    if (await Array.isArray(data.response) && data.response.length) {
-      // If response is an array and has length
-      console.log(`update for ${manufacturer}, ${product}!`)
-      updateAvailability(data.response, product);
-    } else if (await !Array.isArray(data.response)) {
-      // Make the request again
-      console.log(`Failed, retrying for ${manufacturer}, ${product}!`)
+      if (await Array.isArray(data.response) && data.response.length) {
+        console.log(`${manufacturer} data is valid`)
+        // If response is an array and has length store in Redis then update
+        // Save object to redis as a hash
+        resValue[manufacturer] = data.response;
+        client.set(manufacturer, JSON.stringify(resValue), 'EX', cacheTimer);
+        // Evaluate Update
+        // console.log(`update for ${manufacturer}, ${product}!`)
+        // updateAvailability(data.response, product);
+      } else if (await !Array.isArray(data.response)) {
+        // Make the request again
+        console.log(`Failed, retrying for ${manufacturer}, ${product}!`);
+        fetchManufacturerAvailability(manufacturer, product);
+      };
+    } catch (err) {
+      console.log(err)
+      console.log(`Retrying for ${manufacturer} - ${product}`);
       fetchManufacturerAvailability(manufacturer, product);
-    }
-  } catch (err) {
-    console.log(err)
-    console.log(`Retrying for ${manufacturer} - ${product}`)
-    fetchManufacturerAvailability(manufacturer, product);
-  }
-}
+    };
+  };
+};
 
 module.exports = fetchManufacturerAvailability;

--- a/api/fetch-products.js
+++ b/api/fetch-products.js
@@ -2,28 +2,42 @@ const query = require('../db/index.js');
 const dotenv = require('dotenv');
 const fetch = require('node-fetch');
 const fetchManufacturerAvailability = require('./fetch-manufacturer-availability.js');
+const updateAvailability = require('../db/update-availability.js');
 const insertProduct = require('../db/insert-product.js');
 const deleteProduct = require('../db/delete-product.js');
+const { promisify } = require("util");
 
-if (process.env.NODE_ENV !== 'production') {
-  dotenv.config();
-}
+if (process.env.NODE_ENV !== 'production') dotenv.config();
+
+// Init Redis
+const redis_url = process.env.REDIS_URL || null;
+const redis = require("redis");
+const client = redis.createClient(redis_url);
+
+client.on("error", (error) => console.error(error));
+const getAsync = promisify(client.get).bind(client);
+const cacheTimer = process.env.CACHE_TIMER || 300;
+
+// Get value from Redis that depends upon an async call
+const getResult = async (manufacturer) => {
+  try {
+    return await getAsync(manufacturer);
+  } catch (err) {
+    console.log(err);
+  };
+};
 
 const processColors = (colorArray) => {
   let colors = "";
   if (colorArray.length > 1) {
     colorArray.forEach((color, index) => {
-      if (colorArray.length - 1 === index){
-        colors += `${color}`
-      } else {
-        colors += `${color}, `
-      }
-    })
+      (colorArray.length - 1 === index) ? colors += `${color}` : colors += `${color}, `;
+    });
   } else {
     colors = colorArray[0];
-  }
+  };
   return colors;
-}
+};
 
 const fetchProducts = async (product) => {
   let productIDs = [];
@@ -46,34 +60,50 @@ const fetchProducts = async (product) => {
 
       await data.forEach(item => {
         // Build manufacturers array
-        if (!manufacturers.includes(item.manufacturer)) {
-          manufacturers.push(item.manufacturer);
-        }
+        if (!manufacturers.includes(item.manufacturer)) manufacturers.push(item.manufacturer);
 
         // Build an array of product IDs
         productIDs.push(item.id);
 
         // Process colors
-        let colors = processColors(item.color)
+        let colors = processColors(item.color);
 
         // Test if an ID exists in the product's DB, insert else update
         insertProduct(product, item, colors);
       })
 
-      // Fetch availability data
-      manufacturers.forEach(manufacturer => {
-        fetchManufacturerAvailability(manufacturer, product);
-      });
+      // Get availability data
+      for (const manufacturer of manufacturers) {
+        let manufacturersFetched = JSON.parse(await getResult('manufacturer-list'));
+
+        if (!manufacturersFetched) {
+          manufacturersFetched = {
+            'manufacturer-list': []
+          };
+          console.log('init', manufacturersFetched);
+        };
+        if (!manufacturersFetched['manufacturer-list'].includes(manufacturer)) {
+          // IF not in Redis, fetch it
+          console.log('Calling to fetch', manufacturersFetched['manufacturer-list'], 'does not include', manufacturer);
+          fetchManufacturerAvailability(manufacturer, product);
+
+          // Save manufacturer to Redis
+          manufacturersFetched['manufacturer-list'].push(manufacturer);
+          client.set('manufacturer-list', JSON.stringify({
+            'manufacturer-list': manufacturersFetched['manufacturer-list']
+          }), 'EX', cacheTimer);
+        };
+      };
     } else if (await !Array.isArray(data.response)) {
       // Make the request again
-      console.log('failed, try again!')
+      console.log(`failed to fetch ${product} try again!`);
       fetchProducts(product);
-    }
+    };
   } catch(err) {
-     // TODO: Handle
-     return err
-  }
-}
+     fetchProducts(product);
+     console.log(err);
+  };
+};
 
 module.exports = fetchProducts;
 

--- a/db/delete-product.js
+++ b/db/delete-product.js
@@ -1,21 +1,26 @@
-const query = require('./index.js');
-const format = require('pg-format');
+const query = require("./index.js");
+const format = require("pg-format");
 
 const deleteProduct = async (product, productIDs) => {
   // Keep DB in sync with latest API fetch
   try {
-    let deleteSelect = format('SELECT %I FROM %I', 'id', product)
+    let deleteSelect = format("SELECT %I FROM %I", "id", product);
     let tableIDs = await query(deleteSelect);
-    tableIDs.rows.forEach(row => {
+    tableIDs.rows.forEach((row) => {
       if (!productIDs.includes(row.id)) {
         // Delete the record
-        let deleteQuery = format('DELETE FROM %I WHERE %I = %L', product, 'id', row.id)
+        let deleteQuery = format(
+          "DELETE FROM %I WHERE %I = %L",
+          product,
+          "id",
+          row.id
+        );
         query(deleteQuery);
       }
-    })
+    });
   } catch (err) {
     console.log(err);
   }
-}
+};
 
 module.exports = deleteProduct;

--- a/db/get-product-items.js
+++ b/db/get-product-items.js
@@ -1,9 +1,9 @@
-const query = require('./index.js');
-const format = require('pg-format');
+const query = require("./index.js");
+const format = require("pg-format");
 const { promisify } = require("util");
-const dotenv = require('dotenv');
+const dotenv = require("dotenv");
 
-if (process.env.NODE_ENV !== 'production') {
+if (process.env.NODE_ENV !== "production") {
   dotenv.config();
 }
 
@@ -19,31 +19,35 @@ const getAsync = promisify(client.get).bind(client);
 
 const getResult = async (req) => {
   try {
-    return await getAsync(req.header('X-PRODUCT'));
-
+    return await getAsync(req.header("X-PRODUCT"));
   } catch (err) {
     console.log(err);
   }
-}
+};
 
 const getProductItems = async (req, res) => {
   // Get product's stored hash if available
   let result = JSON.parse(await getResult(req));
   let resValue = {};
 
-  if (!result ) {
+  if (!result) {
     // If no stored hash, get it from the DB
     const cacheTimer = process.env.CACHE_TIMER || 300;
-    let queryString = format('SELECT * FROM %I', req.header('X-PRODUCT'));
+    let queryString = format("SELECT * FROM %I", req.header("X-PRODUCT"));
     result = await query(queryString);
 
-    resValue[req.header('X-PRODUCT')] = result.rows;
+    resValue[req.header("X-PRODUCT")] = result.rows;
     // Save object to redis as a hash
-    client.set(req.header('X-PRODUCT'), JSON.stringify(resValue), 'EX', cacheTimer);
+    client.set(
+      req.header("X-PRODUCT"),
+      JSON.stringify(resValue),
+      "EX",
+      cacheTimer
+    );
   } else {
     resValue = result;
   }
   res.json(resValue);
-}
+};
 
 module.exports = getProductItems;

--- a/db/get-product-items.js
+++ b/db/get-product-items.js
@@ -1,11 +1,15 @@
 const query = require("./index.js");
 const format = require("pg-format");
-const { getRedisValue, getResult, client } = require("../shared/init-redis-client.js");
+const {
+  getRedisValue,
+  getResult,
+  client,
+} = require("../shared/init-redis-client.js");
 const { CACHE_TIMER } = require("../shared/constants.js");
 
 const getProductItems = async (req, res) => {
   // Get product's stored hash if available
-  let result = JSON.parse(await getResult(req.header('X-PRODUCT')));
+  let result = JSON.parse(await getResult(req.header("X-PRODUCT")));
   let resValue = {};
 
   if (!result) {

--- a/db/get-product-items.js
+++ b/db/get-product-items.js
@@ -8,14 +8,11 @@ if (process.env.NODE_ENV !== 'production') {
 }
 
 // Redis
-const url = process.env.REDIS_URL || null;
+const redis_url = process.env.REDIS_URL || null;
 const redis = require("redis");
-const client = redis.createClient(url);
+const client = redis.createClient(redis_url);
 
-client.on("error", (error) => {
-  console.error(error);
-});
-
+client.on("error", (error) => console.error(error));
 const getAsync = promisify(client.get).bind(client);
 
 // Response
@@ -30,10 +27,8 @@ const getResult = async (req) => {
 }
 
 const getProductItems = async (req, res) => {
-  let result;
-
   // Get product's stored hash if available
-  result = JSON.parse(await getResult(req));
+  let result = JSON.parse(await getResult(req));
   let resValue = {};
 
   if (!result ) {

--- a/db/get-product-items.js
+++ b/db/get-product-items.js
@@ -1,11 +1,11 @@
 const query = require("./index.js");
 const format = require("pg-format");
-const { getResult, client } = require("../shared/init-redis-client.js");
+const { getRedisValue, getResult, client } = require("../shared/init-redis-client.js");
 const { CACHE_TIMER } = require("../shared/constants.js");
 
 const getProductItems = async (req, res) => {
   // Get product's stored hash if available
-  let result = JSON.parse(await getResult(req));
+  let result = JSON.parse(await getResult(req.header('X-PRODUCT')));
   let resValue = {};
 
   if (!result) {

--- a/db/index.js
+++ b/db/index.js
@@ -22,7 +22,7 @@ if (process.env.NODE_ENV !== 'production') {
       rejectUnauthorized: false
     }
   });
-}
+};
 
 // DB Config
 let today;

--- a/db/index.js
+++ b/db/index.js
@@ -1,38 +1,42 @@
-const { Pool } = require('pg');
-const dotenv = require('dotenv');
+const { Pool } = require("pg");
+const dotenv = require("dotenv");
 let pool;
 
-if (process.env.NODE_ENV !== 'production') {
+if (process.env.NODE_ENV !== "production") {
   dotenv.config();
 
-  const dbName = process.env.NODE_ENV === 'test' ? process.env.DATABASE_NAME_TEST : process.env.DATABASE_NAME;
+  const dbName =
+    process.env.NODE_ENV === "test"
+      ? process.env.DATABASE_NAME_TEST
+      : process.env.DATABASE_NAME;
 
   // Use local DB
   pool = new Pool({
     user: process.env.USER,
     host: process.env.HOST,
     database: dbName,
-    password: process.env.PASSWORD
+    password: process.env.PASSWORD,
   });
 } else {
   // Use production DB
   pool = new Pool({
     connectionString: process.env.DATABASE_URL,
     ssl: {
-      rejectUnauthorized: false
-    }
+      rejectUnauthorized: false,
+    },
   });
-};
+}
 
 // DB Config
 let today;
 let time;
 
-const query = async (text, params) => { // params is an array
+const query = async (text, params) => {
+  // params is an array
   const start = Date.now();
   const res = await pool.query(text, params);
   const duration = Date.now() - start;
-  console.log('executed query', { text, duration, rows: res.rowCount });
+  console.log("executed query", { text, duration, rows: res.rowCount });
   today = new Date();
   time = today.getHours() + ":" + today.getMinutes() + ":" + today.getSeconds();
   console.log(time);

--- a/db/insert-product.js
+++ b/db/insert-product.js
@@ -1,28 +1,47 @@
-const query = require('./index.js');
-const updateProduct = require('../db/update-product.js');
-const format = require('pg-format');
+const query = require("./index.js");
+const updateProduct = require("../db/update-product.js");
+const format = require("pg-format");
 
 const insertProduct = async (product, item, colors) => {
   try {
     // Check status
-    let insertSelect = format('SELECT EXISTS(SELECT 1 FROM %I WHERE %I = %L)', product, 'id', item.id);
+    let insertSelect = format(
+      "SELECT EXISTS(SELECT 1 FROM %I WHERE %I = %L)",
+      product,
+      "id",
+      item.id
+    );
     let result = await query(insertSelect);
     // If it does not exist, insert
 
     if (!result.rows[0].exists) {
-      let insertQuery = format('INSERT INTO %I (%I, %I, %I, %I, %I, %I, %I) \
-        VALUES (%L, %L, %L, %L, %L, %L, %L)', product,
-        'id', 'type', 'name', 'color', 'price', 'manufacturer', 'availability',
-        item.id, item.type, item.name, colors, item.price, item.manufacturer, "Availability Unknown"
-        );
+      let insertQuery = format(
+        "INSERT INTO %I (%I, %I, %I, %I, %I, %I, %I) \
+        VALUES (%L, %L, %L, %L, %L, %L, %L)",
+        product,
+        "id",
+        "type",
+        "name",
+        "color",
+        "price",
+        "manufacturer",
+        "availability",
+        item.id,
+        item.type,
+        item.name,
+        colors,
+        item.price,
+        item.manufacturer,
+        "Availability Unknown"
+      );
       query(insertQuery);
     } else {
       // If it does exist, check if it needs to be updated
       updateProduct(product, item, colors);
-    };
-  } catch(err) {
+    }
+  } catch (err) {
     console.log(err);
-  };
+  }
 };
 
 module.exports = insertProduct;

--- a/db/insert-product.js
+++ b/db/insert-product.js
@@ -5,7 +5,7 @@ const format = require('pg-format');
 const insertProduct = async (product, item, colors) => {
   try {
     // Check status
-    let insertSelect = format('SELECT EXISTS(SELECT 1 FROM %I WHERE %I = %L)', product, 'id', item.id)
+    let insertSelect = format('SELECT EXISTS(SELECT 1 FROM %I WHERE %I = %L)', product, 'id', item.id);
     let result = await query(insertSelect);
     // If it does not exist, insert
 
@@ -19,12 +19,10 @@ const insertProduct = async (product, item, colors) => {
     } else {
       // If it does exist, check if it needs to be updated
       updateProduct(product, item, colors);
-
-    }
+    };
   } catch(err) {
-    console.log(err)
-  }
-}
+    console.log(err);
+  };
+};
 
-// export default insertProduct;
 module.exports = insertProduct;

--- a/db/update-availability.js
+++ b/db/update-availability.js
@@ -1,27 +1,6 @@
 const query = require("./index.js");
 const format = require("pg-format");
-const { promisify } = require("util");
-const dotenv = require("dotenv");
-
-if (process.env.NODE_ENV !== "production") dotenv.config();
-
-// Init Redis
-const redis_url = process.env.REDIS_URL || null;
-const client = require("redis").createClient(redis_url);
-
-client.on("error", (error) => console.error(error));
-const getAsync = promisify(client.get).bind(client);
-
-// Get value from Redis that depends upon an async call
-const getResult = async (val) => {
-  try {
-    return await getAsync(val);
-  } catch (err) {
-    console.log(err);
-  }
-};
-
-const getRedisValue = async (key) => JSON.parse(await getResult(key));
+const { getRedisValue } = require("../shared/init-redis-client.js");
 
 const updateAvailability = async (manufacturers, product) => {
   // Keep DB in sync with latest API fetch

--- a/db/update-availability.js
+++ b/db/update-availability.js
@@ -1,9 +1,9 @@
-const query = require('./index.js');
-const format = require('pg-format');
+const query = require("./index.js");
+const format = require("pg-format");
 const { promisify } = require("util");
-const dotenv = require('dotenv');
+const dotenv = require("dotenv");
 
-if (process.env.NODE_ENV !== 'production') dotenv.config();
+if (process.env.NODE_ENV !== "production") dotenv.config();
 
 // Init Redis
 const redis_url = process.env.REDIS_URL || null;
@@ -18,46 +18,64 @@ const getResult = async (val) => {
     return await getAsync(val);
   } catch (err) {
     console.log(err);
-  };
+  }
 };
+
+const getRedisValue = async (key) => JSON.parse(await getResult(key));
 
 const updateAvailability = async (manufacturers, product) => {
   // Keep DB in sync with latest API fetch
   try {
-    let productsQuery = format('SELECT %I, %I FROM %I', 'id', 'availability', product);
+    let productsQuery = format(
+      "SELECT %I, %I FROM %I",
+      "id",
+      "availability",
+      product
+    );
     let tableIDs = await query(productsQuery);
     let datapayload;
     let ind;
     let availability;
 
     for (const manufacturer of manufacturers) {
-      let manufacturerData = JSON.parse(await getResult(manufacturer));
+      let manufacturerPromise = getRedisValue(manufacturer);
+      manufacturerPromise.then((manufacturerData) => {
+        manufacturerData[manufacturer].forEach((value) => {
+          // Each value found in manufacturer's availability data
+          ind = tableIDs.rows.findIndex((x) => x.id === value.id.toLowerCase());
+          if (ind !== -1) {
+            // ind equals -1 if id not found in data response (product records)
+            datapayload = value.DATAPAYLOAD.match(
+              /<INSTOCKVALUE>(.*)<\/INSTOCKVALUE>/
+            );
+            if (datapayload) {
+              if (datapayload[1] === "OUTOFSTOCK") {
+                availability = "Out of Stock";
+              } else if (datapayload[1] === "INSTOCK") {
+                availability = "In Stock";
+              } else if (datapayload[1] === "LESSTHAN10") {
+                availability = "Less Than 10";
+              }
+            }
 
-      manufacturerData[manufacturer].forEach(value => { // Each value found in manufacturer's availability data
-        ind = tableIDs.rows.findIndex(x => x.id === value.id.toLowerCase());
-        if (ind !== -1) { // ind equals -1 if id not found in data response (product records)
-          datapayload = value.DATAPAYLOAD.match(/<INSTOCKVALUE>(.*)<\/INSTOCKVALUE>/);
-          if (datapayload) {
-            if (datapayload[1] === "OUTOFSTOCK") {
-              availability = "Out of Stock";
-            } else if (datapayload[1] === "INSTOCK") {
-              availability = "In Stock";
-            } else if (datapayload[1] === "LESSTHAN10") {
-              availability = "Less Than 10";
-            };
-          };
-
-          // If API response's availability differs from what is in the DB
-          if (availability !== tableIDs.rows[ind].availability) {
-            let availabilityUpdate = format('UPDATE %I SET %I = %L WHERE id = %L', product, 'availability', availability, value.id.toLowerCase());
-            query(availabilityUpdate);
-          };
-        };
+            // If API response's availability differs from what is in the DB
+            if (availability !== tableIDs.rows[ind].availability) {
+              let availabilityUpdate = format(
+                "UPDATE %I SET %I = %L WHERE id = %L",
+                product,
+                "availability",
+                availability,
+                value.id.toLowerCase()
+              );
+              query(availabilityUpdate);
+            }
+          }
+        });
       });
-    };
+    }
   } catch (err) {
     console.log(err);
-  };
+  }
 };
 
 module.exports = updateAvailability;

--- a/db/update-availability.js
+++ b/db/update-availability.js
@@ -1,17 +1,39 @@
 const query = require('./index.js');
 const format = require('pg-format');
+const { promisify } = require("util");
+const dotenv = require('dotenv');
 
-const updateAvailability = async (data, product) => {
+if (process.env.NODE_ENV !== 'production') dotenv.config();
+
+// Init Redis
+const redis_url = process.env.REDIS_URL || null;
+const client = require("redis").createClient(redis_url);
+
+client.on("error", (error) => console.error(error));
+const getAsync = promisify(client.get).bind(client);
+
+// Get value from Redis that depends upon an async call
+const getResult = async (val) => {
+  try {
+    return await getAsync(val);
+  } catch (err) {
+    console.log(err);
+  };
+};
+
+const updateAvailability = async (manufacturers, product) => {
   // Keep DB in sync with latest API fetch
   try {
-
     let productsQuery = format('SELECT %I, %I FROM %I', 'id', 'availability', product);
     let tableIDs = await query(productsQuery);
     let datapayload;
     let ind;
     let availability;
 
-    data.forEach(value => { // Each value found in manufacturer's availability data
+    for (const manufacturer of manufacturers) {
+      let manufacturerData = JSON.parse(await getResult(manufacturer));
+
+      manufacturerData[manufacturer].forEach(value => { // Each value found in manufacturer's availability data
         ind = tableIDs.rows.findIndex(x => x.id === value.id.toLowerCase());
         if (ind !== -1) { // ind equals -1 if id not found in data response (product records)
           datapayload = value.DATAPAYLOAD.match(/<INSTOCKVALUE>(.*)<\/INSTOCKVALUE>/);
@@ -22,19 +44,20 @@ const updateAvailability = async (data, product) => {
               availability = "In Stock";
             } else if (datapayload[1] === "LESSTHAN10") {
               availability = "Less Than 10";
-            }
-          }
+            };
+          };
 
           // If API response's availability differs from what is in the DB
           if (availability !== tableIDs.rows[ind].availability) {
             let availabilityUpdate = format('UPDATE %I SET %I = %L WHERE id = %L', product, 'availability', availability, value.id.toLowerCase());
             query(availabilityUpdate);
-          }
-        }
-      })
+          };
+        };
+      });
+    };
   } catch (err) {
-    console.log(err)
-  }
-}
+    console.log(err);
+  };
+};
 
 module.exports = updateAvailability;

--- a/db/update-product.js
+++ b/db/update-product.js
@@ -7,7 +7,7 @@ const updateProduct = async (product, item, colors) => {
       FROM %I \
       WHERE %I = %L',
       'type', 'name', 'color', 'price', 'manufacturer', product, 'id', item.id
-    )
+    );
     let recordValues = await query(updateSelect);
     // Split to get each column value
     let array = recordValues.rows[0].row.split(',');
@@ -22,43 +22,43 @@ const updateProduct = async (product, item, colors) => {
       // Update type in DB
       const cond1 = format('%I = %L', 'type', item.type);
       updateObject.array.push(cond1);
-    }
+    };
 
     if (item.name !== array[1].replace(/["]+/g, '')) {
       // Update name in DB
       const cond2 = format('%I = %L', 'name', item.name);
       updateObject.array.push(cond2);
-    }
+    };
     let recordColors = array[2].replace(/["]+/g, '');
     if (array.length === 6) {
       // If there are two colors
       recordColors = recordColors + "," + array[3].replace(/["]+/g, '');
-    }
+    };
     if (colors !== recordColors) {
       // Update color in DB
       const cond3 = format('%I = %L', 'color', colors);
       updateObject.array.push(cond3);
-    }
+    };
     if (item.price !== Number.parseInt(array[array.length - 2]))  {
       // Update price in DB
       const cond4 = format('%I = %L', 'price', item.price);
       updateObject.array.push(cond4);
-    }
+    };
 
     if (item.manufacturer !== array[array.length - 1].replace(/\"|\)+/g, '')) {
       // Update manufacturer in DB
       const cond5 = format('%I = %L', 'manufacturer', item.manufacturer);
       updateObject.array.push(cond5);
-    }
+    };
 
     if (updateObject.array.length) {
       cond_string = updateObject.array.join(', ')
       let updateQuery = format('UPDATE %I SET %s WHERE id = %L', product, cond_string, item.id);
       query(updateQuery);
-    }
+    };
   } catch (err) {
     console.log(err);
-  }
-}
+  };
+};
 
 module.exports = updateProduct;

--- a/db/update-product.js
+++ b/db/update-product.js
@@ -1,64 +1,77 @@
-const query = require('./index.js');
-const format = require('pg-format');
+const query = require("./index.js");
+const format = require("pg-format");
 
 const updateProduct = async (product, item, colors) => {
   try {
-    let updateSelect = format('SELECT (%I, %I, %I, %I, %I) \
+    let updateSelect = format(
+      "SELECT (%I, %I, %I, %I, %I) \
       FROM %I \
-      WHERE %I = %L',
-      'type', 'name', 'color', 'price', 'manufacturer', product, 'id', item.id
+      WHERE %I = %L",
+      "type",
+      "name",
+      "color",
+      "price",
+      "manufacturer",
+      product,
+      "id",
+      item.id
     );
     let recordValues = await query(updateSelect);
     // Split to get each column value
-    let array = recordValues.rows[0].row.split(',');
+    let array = recordValues.rows[0].row.split(",");
 
     let string = "";
     let stringValues = "";
-    const updateObject ={
-      array: []
+    const updateObject = {
+      array: [],
     };
 
-    if (item.type !== array[0].replace(/\"|\(+/g, '')) {
+    if (item.type !== array[0].replace(/\"|\(+/g, "")) {
       // Update type in DB
-      const cond1 = format('%I = %L', 'type', item.type);
+      const cond1 = format("%I = %L", "type", item.type);
       updateObject.array.push(cond1);
-    };
+    }
 
-    if (item.name !== array[1].replace(/["]+/g, '')) {
+    if (item.name !== array[1].replace(/["]+/g, "")) {
       // Update name in DB
-      const cond2 = format('%I = %L', 'name', item.name);
+      const cond2 = format("%I = %L", "name", item.name);
       updateObject.array.push(cond2);
-    };
-    let recordColors = array[2].replace(/["]+/g, '');
+    }
+    let recordColors = array[2].replace(/["]+/g, "");
     if (array.length === 6) {
       // If there are two colors
-      recordColors = recordColors + "," + array[3].replace(/["]+/g, '');
-    };
+      recordColors = recordColors + "," + array[3].replace(/["]+/g, "");
+    }
     if (colors !== recordColors) {
       // Update color in DB
-      const cond3 = format('%I = %L', 'color', colors);
+      const cond3 = format("%I = %L", "color", colors);
       updateObject.array.push(cond3);
-    };
-    if (item.price !== Number.parseInt(array[array.length - 2]))  {
+    }
+    if (item.price !== Number.parseInt(array[array.length - 2])) {
       // Update price in DB
-      const cond4 = format('%I = %L', 'price', item.price);
+      const cond4 = format("%I = %L", "price", item.price);
       updateObject.array.push(cond4);
-    };
+    }
 
-    if (item.manufacturer !== array[array.length - 1].replace(/\"|\)+/g, '')) {
+    if (item.manufacturer !== array[array.length - 1].replace(/\"|\)+/g, "")) {
       // Update manufacturer in DB
-      const cond5 = format('%I = %L', 'manufacturer', item.manufacturer);
+      const cond5 = format("%I = %L", "manufacturer", item.manufacturer);
       updateObject.array.push(cond5);
-    };
+    }
 
     if (updateObject.array.length) {
-      cond_string = updateObject.array.join(', ')
-      let updateQuery = format('UPDATE %I SET %s WHERE id = %L', product, cond_string, item.id);
+      cond_string = updateObject.array.join(", ");
+      let updateQuery = format(
+        "UPDATE %I SET %s WHERE id = %L",
+        product,
+        cond_string,
+        item.id
+      );
       query(updateQuery);
-    };
+    }
   } catch (err) {
     console.log(err);
-  };
+  }
 };
 
 module.exports = updateProduct;

--- a/index.js
+++ b/index.js
@@ -1,10 +1,10 @@
-const express = require('express');
-const cors = require('cors');
-const dotenv = require('dotenv');
-const bodyParser = require('body-parser');
-const getProductItems = require('./db/get-product-items.js')
-const cronFetch = require('./jobs/cron-fetch.js');
-const updateAvailability = require('./db/update-availability.js');
+const express = require("express");
+const cors = require("cors");
+const dotenv = require("dotenv");
+const bodyParser = require("body-parser");
+const getProductItems = require("./db/get-product-items.js");
+const cronFetch = require("./jobs/cron-fetch.js");
+const updateAvailability = require("./db/update-availability.js");
 
 // Init Redis
 const { promisify } = require("util");
@@ -19,24 +19,26 @@ const app = express();
 const port = process.env.PORT || 3010;
 
 // Port
-app.set('port', port);
+app.set("port", port);
 
-app.listen(app.get('port'), () => {
-  console.log('Proxy server listening on port ' + app.get('port'));
+app.listen(app.get("port"), () => {
+  console.log("Proxy server listening on port " + app.get("port"));
 });
 
 // Handle CORS
 app.use(cors());
 
-var myLimit = typeof(process.argv[2]) != 'undefined' ? process.argv[2] : '100kb';
-  console.log('Using limit: ', myLimit);
+var myLimit = typeof process.argv[2] != "undefined" ? process.argv[2] : "100kb";
+console.log("Using limit: ", myLimit);
 
-app.use(bodyParser.json({
-  limit: myLimit
-}));
+app.use(
+  bodyParser.json({
+    limit: myLimit,
+  })
+);
 
 // Environment vars
-if (process.env.NODE_ENV !== 'production') {
+if (process.env.NODE_ENV !== "production") {
   dotenv.config();
 
   // Run DB update Job every CRON_IN_MINUTES
@@ -44,19 +46,19 @@ if (process.env.NODE_ENV !== 'production') {
 }
 
 // Auth
-app.get('*', (req, res, next) => {
-  const token = req.header('X-WEB-TOKEN');
+app.get("*", (req, res, next) => {
+  const token = req.header("X-WEB-TOKEN");
   if (!token) {
     return res.sendStatus(401); // If there isn't any token
   } else if (token !== process.env.ACCESS_TOKEN_SECRET) {
     return res.sendStatus(403); // If wrong token
   } else {
     next();
-  }
+  };
 });
 
 // Return custom API response from DB
-app.get('/', (req, res) => {
+app.get("/", (req, res) => {
   getProductItems(req, res);
 });
 
@@ -71,54 +73,62 @@ const getResult = async (val) => {
 
 const getRedisValue = async (key) => JSON.parse(await getResult(key));
 
-
-const KEY_EVENT_SET = '__keyevent@0__:set';
+const KEY_EVENT_SET = "__keyevent@0__:set";
 let updatePromise;
 let manufacturersPromise;
 
-const ignoreKeyList = [
-  'manufacturer-list',
-  'beanies',
-  'facemasks',
-  'gloves'
-]
+const ignoreKeyList = ["manufacturer-list", "beanies", "facemasks", "gloves"];
 
 subscriber.on("pmessage", (pattern, channel, message) => {
-  console.log("("+  pattern +")" + " client received message on " + channel + ": " + message);
+  console.log(
+    "(" +
+      pattern +
+      ")" +
+      " client received message on " +
+      channel +
+      ": " +
+      message
+  );
   if (channel === KEY_EVENT_SET && !ignoreKeyList.includes(message)) {
-    manufacturersPromise = getRedisValue('manufacturer-list');
-    updatePromise = getRedisValue('update-ready');
-    manufacturersPromise.then(manufacturers => {
-      if (manufacturers['manufacturer-list'].includes(message)) {
-        updatePromise.then(updateReady => {
+    manufacturersPromise = getRedisValue("manufacturer-list");
+    updatePromise = getRedisValue("update-ready");
+    manufacturersPromise.then((manufacturers) => {
+      if (manufacturers["manufacturer-list"].includes(message)) {
+        updatePromise.then((updateReady) => {
           if (!updateReady) {
-            updateReady = {'update-ready': [message]};
-            console.log('init', updateReady);
+            updateReady = { "update-ready": [message] };
+            console.log("Init:", updateReady);
           } else {
-            if (!updateReady['update-ready'].includes(message)){
-              updateReady['update-ready'].push(message);
-              console.log('push', updateReady);
+            if (!updateReady["update-ready"].includes(message)) {
+              updateReady["update-ready"].push(message);
+              console.log("Add to updateReady array:", updateReady);
             };
           };
-          client.set(('update-ready'), JSON.stringify(updateReady), 'EX', cacheTimer);
+          client.set(
+            "update-ready",
+            JSON.stringify(updateReady),
+            "EX",
+            cacheTimer
+          );
         });
       };
-      if (message === 'update-ready') {
-        updatePromise.then(updateReady => {
-          if (updateReady['update-ready'].length === 6) {
-            console.log('Update is a go', manufacturers['manufacturer-list']);
-            const products = ['beanies', 'facemasks', 'gloves'];
-            products.forEach((product, index) => setTimeout(updateAvailability, 100 * index, manufacturers['manufacturer-list'], product));
+      if (message === "update-ready") {
+        updatePromise.then((updateReady) => {
+          if (updateReady["update-ready"].length === 6) {
+            console.log("Update is a go", manufacturers["manufacturer-list"]);
+            const products = ["beanies", "facemasks", "gloves"];
+            products.forEach((product, index) =>
+              setTimeout(
+                updateAvailability,
+                100 * index,
+                manufacturers["manufacturer-list"],
+                product
+              )
+            );
           };
         });
       };
     });
   };
 });
-subscriber.psubscribe('__key*__:*');
-
-
-
-
-
-
+subscriber.psubscribe("__key*__:*");

--- a/index.js
+++ b/index.js
@@ -4,15 +4,7 @@ const dotenv = require("dotenv");
 const bodyParser = require("body-parser");
 const getProductItems = require("./db/get-product-items.js");
 const cronFetch = require("./jobs/cron-fetch.js");
-const updateAvailability = require("./db/update-availability.js");
-
-// Init Redis
-const { promisify } = require("util");
-const redis_url = process.env.REDIS_URL || null;
-const subscriber = require("redis").createClient(redis_url);
-const client = require("redis").createClient(redis_url);
-const getAsync = promisify(client.get).bind(client);
-const cacheTimer = process.env.CACHE_TIMER || 300;
+const subscriberInit = require("./shared/subscriber-init.js");
 
 // App Setup
 const app = express();
@@ -43,79 +35,10 @@ if (process.env.NODE_ENV !== "production") {
 
   // Run DB update Job every CRON_IN_MINUTES
   cronFetch();
+
+  // Subscribe to Redis keyspace channels
+  subscriberInit();
 }
-
-// Get value from Redis that depends upon an async call
-const getResult = async (val) => {
-  try {
-    return await getAsync(val);
-  } catch (err) {
-    console.log(err);
-  }
-};
-
-const getRedisValue = async (key) => JSON.parse(await getResult(key));
-
-const KEY_EVENT_SET = "__keyevent@0__:set";
-let updatePromise;
-let manufacturersPromise;
-
-const ignoreKeyList = ["manufacturer-list", "beanies", "facemasks", "gloves"];
-
-// Redis subscriber to determine when to update availability column
-subscriber.on("pmessage", (pattern, channel, message) => {
-  console.log(
-    "(" +
-      pattern +
-      ")" +
-      " client received message on " +
-      channel +
-      ": " +
-      message
-  );
-  if (channel === KEY_EVENT_SET && !ignoreKeyList.includes(message)) {
-    manufacturersPromise = getRedisValue("manufacturer-list");
-    updatePromise = getRedisValue("update-ready");
-    manufacturersPromise.then((manufacturers) => {
-      if (manufacturers["manufacturer-list"].includes(message)) {
-        updatePromise.then((updateReady) => {
-          if (!updateReady) {
-            updateReady = { "update-ready": [message] };
-            console.log("init", updateReady);
-          } else {
-            if (!updateReady["update-ready"].includes(message)) {
-              updateReady["update-ready"].push(message);
-              console.log("push", updateReady);
-            }
-          }
-          client.set(
-            "update-ready",
-            JSON.stringify(updateReady),
-            "EX",
-            cacheTimer
-          );
-        });
-      }
-      if (message === "update-ready") {
-        updatePromise.then((updateReady) => {
-          if (updateReady["update-ready"].length === 6) {
-            console.log("Update is a go", manufacturers["manufacturer-list"]);
-            const products = ["beanies", "facemasks", "gloves"];
-            products.forEach((product, index) =>
-              setTimeout(
-                updateAvailability,
-                100 * index,
-                manufacturers["manufacturer-list"],
-                product
-              )
-            );
-          }
-        });
-      }
-    });
-  }
-});
-subscriber.psubscribe("__key*__:*");
 
 // Auth
 app.get("*", (req, res, next) => {

--- a/index.js
+++ b/index.js
@@ -4,7 +4,17 @@ const dotenv = require('dotenv');
 const bodyParser = require('body-parser');
 const getProductItems = require('./db/get-product-items.js')
 const cronFetch = require('./jobs/cron-fetch.js');
+const updateAvailability = require('./db/update-availability.js');
 
+// Init Redis
+const { promisify } = require("util");
+const redis_url = process.env.REDIS_URL || null;
+const subscriber = require("redis").createClient(redis_url);
+const client = require("redis").createClient(redis_url);
+const getAsync = promisify(client.get).bind(client);
+const cacheTimer = process.env.CACHE_TIMER || 300;
+
+// App Setup
 const app = express();
 const port = process.env.PORT || 3010;
 
@@ -48,7 +58,64 @@ app.get('*', (req, res, next) => {
 // Return custom API response from DB
 app.get('/', (req, res) => {
   getProductItems(req, res);
-})
+});
+
+// Get value from Redis that depends upon an async call
+const getResult = async (val) => {
+  try {
+    return await getAsync(val);
+  } catch (err) {
+    console.log(err);
+  };
+};
+
+const getRedisValue = async (key) => JSON.parse(await getResult(key));
+
+
+const KEY_EVENT_SET = '__keyevent@0__:set';
+let updatePromise;
+let manufacturersPromise;
+
+const ignoreKeyList = [
+  'manufacturer-list',
+  'beanies',
+  'facemasks',
+  'gloves'
+]
+
+subscriber.on("pmessage", (pattern, channel, message) => {
+  console.log("("+  pattern +")" + " client received message on " + channel + ": " + message);
+  if (channel === KEY_EVENT_SET && !ignoreKeyList.includes(message)) {
+    manufacturersPromise = getRedisValue('manufacturer-list');
+    updatePromise = getRedisValue('update-ready');
+    manufacturersPromise.then(manufacturers => {
+      if (manufacturers['manufacturer-list'].includes(message)) {
+        updatePromise.then(updateReady => {
+          if (!updateReady) {
+            updateReady = {'update-ready': [message]};
+            console.log('init', updateReady);
+          } else {
+            if (!updateReady['update-ready'].includes(message)){
+              updateReady['update-ready'].push(message);
+              console.log('push', updateReady);
+            };
+          };
+          client.set(('update-ready'), JSON.stringify(updateReady), 'EX', cacheTimer);
+        });
+      };
+      if (message === 'update-ready') {
+        updatePromise.then(updateReady => {
+          if (updateReady['update-ready'].length === 6) {
+            console.log('Update is a go', manufacturers['manufacturer-list']);
+            const products = ['beanies', 'facemasks', 'gloves'];
+            products.forEach((product, index) => setTimeout(updateAvailability, 100 * index, manufacturers['manufacturer-list'], product));
+          };
+        });
+      };
+    });
+  };
+});
+subscriber.psubscribe('__key*__:*');
 
 
 

--- a/jobs/cron-fetch.js
+++ b/jobs/cron-fetch.js
@@ -2,30 +2,24 @@ const cron = require('node-cron');
 const fetchProducts = require('../api/fetch-products.js');
 const dotenv = require('dotenv');
 
-if (process.env.NODE_ENV !== 'production') {
-  dotenv.config();
-}
+if (process.env.NODE_ENV !== 'production') dotenv.config();
 
 const task = cron.schedule(`*/${process.env.CRON_IN_MINUTES} * * * *`, () => {
   const products = ['beanies', 'facemasks', 'gloves'];
-  products.forEach(product => {
-    fetchProducts(product);
-  })
+  products.forEach((product, index) => setTimeout(fetchProducts, 5000 * index, product));
 }, {
   scheduled: false
-})
+});
 
 const cronFetch = () => {
   if (process.env.START_CRON) {
     console.log('start cron');
     task.start();
-  }
+  };
   if (process.env.END_CRON) {
     console.log('end cron');
     task.end();
-  }
-}
-
-
+  };
+};
 
 module.exports = cronFetch;

--- a/jobs/cron-fetch.js
+++ b/jobs/cron-fetch.js
@@ -1,25 +1,31 @@
-const cron = require('node-cron');
-const fetchProducts = require('../api/fetch-products.js');
-const dotenv = require('dotenv');
+const cron = require("node-cron");
+const fetchProducts = require("../api/fetch-products.js");
+const dotenv = require("dotenv");
 
-if (process.env.NODE_ENV !== 'production') dotenv.config();
+if (process.env.NODE_ENV !== "production") dotenv.config();
 
-const task = cron.schedule(`*/${process.env.CRON_IN_MINUTES} * * * *`, () => {
-  const products = ['beanies', 'facemasks', 'gloves'];
-  products.forEach((product, index) => setTimeout(fetchProducts, 5000 * index, product));
-}, {
-  scheduled: false
-});
+const task = cron.schedule(
+  `*/${process.env.CRON_IN_MINUTES} * * * *`,
+  () => {
+    const products = ["beanies", "facemasks", "gloves"];
+    products.forEach((product, index) =>
+      setTimeout(fetchProducts, 5000 * index, product)
+    );
+  },
+  {
+    scheduled: false,
+  }
+);
 
 const cronFetch = () => {
   if (process.env.START_CRON) {
-    console.log('start cron');
+    console.log("start cron");
     task.start();
-  };
+  }
   if (process.env.END_CRON) {
-    console.log('end cron');
+    console.log("end cron");
     task.end();
-  };
+  }
 };
 
 module.exports = cronFetch;

--- a/jobs/cron-fetch.js
+++ b/jobs/cron-fetch.js
@@ -1,6 +1,10 @@
 const cron = require("node-cron");
 const fetchProducts = require("../api/fetch-products.js");
-const { CRON_IN_MINUTES, START_CRON, END_CRON } = require("../shared/constants.js");
+const {
+  CRON_IN_MINUTES,
+  START_CRON,
+  END_CRON,
+} = require("../shared/constants.js");
 
 const task = cron.schedule(
   `*/${CRON_IN_MINUTES} * * * *`,

--- a/jobs/cron-fetch.js
+++ b/jobs/cron-fetch.js
@@ -1,11 +1,9 @@
 const cron = require("node-cron");
 const fetchProducts = require("../api/fetch-products.js");
-const dotenv = require("dotenv");
-
-if (process.env.NODE_ENV !== "production") dotenv.config();
+const { CRON_IN_MINUTES, START_CRON, END_CRON } = require("../shared/constants.js");
 
 const task = cron.schedule(
-  `*/${process.env.CRON_IN_MINUTES} * * * *`,
+  `*/${CRON_IN_MINUTES} * * * *`,
   () => {
     const products = ["beanies", "facemasks", "gloves"];
     products.forEach((product, index) =>
@@ -18,11 +16,11 @@ const task = cron.schedule(
 );
 
 const cronFetch = () => {
-  if (process.env.START_CRON) {
+  if (START_CRON) {
     console.log("start cron");
     task.start();
   }
-  if (process.env.END_CRON) {
+  if (END_CRON) {
     console.log("end cron");
     task.end();
   }

--- a/jobs/prod-task.js
+++ b/jobs/prod-task.js
@@ -1,4 +1,6 @@
-const fetchProducts = require('../api/fetch-products.js');
+const fetchProducts = require("../api/fetch-products.js");
 
-const products = ['beanies', 'facemasks', 'gloves'];
-products.forEach((product, index) => setTimeout(fetchProducts, 100 * index, product));
+const products = ["beanies", "facemasks", "gloves"];
+products.forEach((product, index) =>
+  setTimeout(fetchProducts, 5000 * index, product)
+);

--- a/jobs/prod-task.js
+++ b/jobs/prod-task.js
@@ -1,4 +1,4 @@
 const fetchProducts = require('../api/fetch-products.js');
 
 const products = ['beanies', 'facemasks', 'gloves'];
-products.forEach(product => {fetchProducts(product)})
+products.forEach((product, index) => setTimeout(fetchProducts, 100 * index, product));

--- a/jobs/prod-task.js
+++ b/jobs/prod-task.js
@@ -1,6 +1,15 @@
 const fetchProducts = require("../api/fetch-products.js");
+const subscriberInit = require("../shared/subscriber-init.js");
+
+subscriberInit();
 
 const products = ["beanies", "facemasks", "gloves"];
 products.forEach((product, index) =>
   setTimeout(fetchProducts, 5000 * index, product)
 );
+
+// Kill script if it hasn't killed itself
+setTimeout((function() {
+  console.log('timeout');
+  return process.exit(22);
+}), 120000);

--- a/jobs/prod-task.js
+++ b/jobs/prod-task.js
@@ -9,7 +9,7 @@ products.forEach((product, index) =>
 );
 
 // Kill script if it hasn't killed itself
-setTimeout((function() {
-  console.log('timeout');
+setTimeout(() => {
+  console.log("timeout");
   return process.exit(22);
-}), 120000);
+}, 120000);

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "cors": "^2.8.5",
     "dotenv": "^8.2.0",
+    "eslint": "^7.21.0",
     "express": "^4.17.1",
     "node-cron": "^2.0.3",
     "node-fetch": "^2.6.1",
@@ -28,7 +29,7 @@
     "jest": "^26.6.3",
     "supertest": "^6.1.3"
   },
-   "jest": {
+  "jest": {
     "testEnvironment": "node",
     "coveragePathIgnorePatterns": [
       "/node_modules/"

--- a/redis.conf
+++ b/redis.conf
@@ -1,2 +1,2 @@
 timeout 0
-notify-keyspace-events Ks
+notify-keyspace-events KEA

--- a/redis.conf
+++ b/redis.conf
@@ -1,0 +1,2 @@
+timeout 0
+notify-keyspace-events Ks

--- a/shared/constants.js
+++ b/shared/constants.js
@@ -21,5 +21,5 @@ module.exports = {
   KEY_EVENT_SET,
   CRON_IN_MINUTES,
   START_CRON,
-  END_CRON
+  END_CRON,
 };

--- a/shared/constants.js
+++ b/shared/constants.js
@@ -1,0 +1,25 @@
+const dotenv = require("dotenv");
+
+if (process.env.NODE_ENV !== "production") dotenv.config();
+
+const PRODUCT_URL = process.env.PRODUCT_URL;
+const MANUFACTURER_URL = process.env.MANUFACTURER_URL;
+
+const CACHE_TIMER = process.env.CACHE_TIMER || 300;
+const REDIS_URL = process.env.REDIS_URL || null;
+const KEY_EVENT_SET = "__keyevent@0__:set";
+
+const CRON_IN_MINUTES = process.env.CRON_IN_MINUTES || 6;
+const START_CRON = process.env.START_CRON || null;
+const END_CRON = process.env.END_CRON || null;
+
+module.exports = {
+  PRODUCT_URL,
+  MANUFACTURER_URL,
+  CACHE_TIMER,
+  REDIS_URL,
+  KEY_EVENT_SET,
+  CRON_IN_MINUTES,
+  START_CRON,
+  END_CRON
+};

--- a/shared/init-redis-client.js
+++ b/shared/init-redis-client.js
@@ -15,4 +15,4 @@ const getResult = async (val) => {
 
 const getRedisValue = async (key) => JSON.parse(await getResult(key));
 
-module.exports = { getRedisValue, getResult, client };
+module.exports = { getRedisValue;, getResult, client };

--- a/shared/init-redis-client.js
+++ b/shared/init-redis-client.js
@@ -1,0 +1,18 @@
+const { promisify } = require("util");
+const { REDIS_URL } = require("./constants.js")
+const client = require("redis").createClient(REDIS_URL);
+const getAsync = promisify(client.get).bind(client);
+
+client.on("error", (error) => console.error(error));
+
+const getResult = async (val) => {
+  try {
+    return await getAsync(val);
+  } catch (err) {
+    console.log(err);
+  }
+};
+
+const getRedisValue = async (key) => JSON.parse(await getResult(key));
+
+module.exports = { getRedisValue, getResult, client };

--- a/shared/subscriber-init.js
+++ b/shared/subscriber-init.js
@@ -1,6 +1,6 @@
 const updateAvailability = require("../db/update-availability.js");
 const { getRedisValue, client } = require("./init-redis-client.js");
-const { CACHE_TIMER, REDIS_URL, KEY_EVENT_SET } = require("./constants.js")
+const { CACHE_TIMER, REDIS_URL, KEY_EVENT_SET } = require("./constants.js");
 
 const subscriberInit = () => {
   const subscriber = require("redis").createClient(REDIS_URL);
@@ -46,8 +46,15 @@ const subscriberInit = () => {
         }
         if (message === "update-ready") {
           updatePromise.then((updateReady) => {
-            if (updateReady["update-ready"].length === manufacturers['manufacturer-list'].length) {
-              console.log("Update is a go", manufacturers["manufacturer-list"], updateReady["update-ready"]);
+            if (
+              updateReady["update-ready"].length ===
+              manufacturers["manufacturer-list"].length
+            ) {
+              console.log(
+                "Update is a go",
+                manufacturers["manufacturer-list"],
+                updateReady["update-ready"]
+              );
               const products = ["beanies", "facemasks", "gloves"];
               products.forEach((product, index) =>
                 setTimeout(
@@ -64,7 +71,6 @@ const subscriberInit = () => {
     }
   });
   subscriber.psubscribe("__key*__:*");
-
 };
 
 module.exports = subscriberInit;

--- a/shared/subscriber-init.js
+++ b/shared/subscriber-init.js
@@ -1,0 +1,70 @@
+const updateAvailability = require("../db/update-availability.js");
+const { getRedisValue, client } = require("./init-redis-client.js");
+const { CACHE_TIMER, REDIS_URL, KEY_EVENT_SET } = require("./constants.js")
+
+const subscriberInit = () => {
+  const subscriber = require("redis").createClient(REDIS_URL);
+  let updatePromise;
+  let manufacturersPromise;
+
+  // Ignore these Redis hashes when they are set
+  const ignoreKeyList = ["manufacturer-list", "beanies", "facemasks", "gloves"];
+
+  // Redis subscriber to determine when to update availability column
+  subscriber.on("pmessage", (pattern, channel, message) => {
+    console.log(
+      "(" +
+        pattern +
+        ")" +
+        " client received message on " +
+        channel +
+        ": " +
+        message
+    );
+    if (channel === KEY_EVENT_SET && !ignoreKeyList.includes(message)) {
+      manufacturersPromise = getRedisValue("manufacturer-list");
+      updatePromise = getRedisValue("update-ready");
+      manufacturersPromise.then((manufacturers) => {
+        if (manufacturers["manufacturer-list"].includes(message)) {
+          updatePromise.then((updateReady) => {
+            if (!updateReady) {
+              updateReady = { "update-ready": [message] };
+              console.log("init", updateReady);
+            } else {
+              if (!updateReady["update-ready"].includes(message)) {
+                updateReady["update-ready"].push(message);
+                console.log("push", updateReady);
+              }
+            }
+            client.set(
+              "update-ready",
+              JSON.stringify(updateReady),
+              "EX",
+              CACHE_TIMER
+            );
+          });
+        }
+        if (message === "update-ready") {
+          updatePromise.then((updateReady) => {
+            if (updateReady["update-ready"].length === manufacturers['manufacturer-list'].length) {
+              console.log("Update is a go", manufacturers["manufacturer-list"], updateReady["update-ready"]);
+              const products = ["beanies", "facemasks", "gloves"];
+              products.forEach((product, index) =>
+                setTimeout(
+                  updateAvailability,
+                  100 * index,
+                  manufacturers["manufacturer-list"],
+                  product
+                )
+              );
+            }
+          });
+        }
+      });
+    }
+  });
+  subscriber.psubscribe("__key*__:*");
+
+};
+
+module.exports = subscriberInit;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,13 @@
 # yarn lockfile v1
 
 
+"@babel/code-frame@7.12.11":
+  version "7.12.11"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.12.11.tgz#f4ad435aa263db935b8f10f2c552d23fb716a63f"
+  integrity sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==
+  dependencies:
+    "@babel/highlight" "^7.10.4"
+
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.12.13":
   version "7.12.13"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.12.13.tgz#dcfc826beef65e75c50e21d3837d7d95798dd658"
@@ -155,7 +162,7 @@
     "@babel/traverse" "^7.13.0"
     "@babel/types" "^7.13.0"
 
-"@babel/highlight@^7.12.13":
+"@babel/highlight@^7.10.4", "@babel/highlight@^7.12.13":
   version "7.13.8"
   resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.13.8.tgz#10b2dac78526424dfc1f47650d0e415dfd9dc481"
   integrity sha512-4vrIhfJyfNf+lCtXC2ck1rKSzDwciqF7IWFhXXrSOUC2O5DrVp+w4c6ed4AllTxhTkUP5x2tYj41VaxdVMMRDw==
@@ -298,6 +305,21 @@
   dependencies:
     exec-sh "^0.3.2"
     minimist "^1.2.0"
+
+"@eslint/eslintrc@^0.4.0":
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-0.4.0.tgz#99cc0a0584d72f1df38b900fb062ba995f395547"
+  integrity sha512-2ZPCc+uNbjV5ERJr+aKSPRwZgKd2z11x0EgLvb1PURmUrn9QNRXFqje0Ldq454PfAVyaJYyrDvvIKSFP4NnBog==
+  dependencies:
+    ajv "^6.12.4"
+    debug "^4.1.1"
+    espree "^7.3.0"
+    globals "^12.1.0"
+    ignore "^4.0.6"
+    import-fresh "^3.2.1"
+    js-yaml "^3.13.1"
+    minimatch "^3.0.4"
+    strip-json-comments "^3.1.1"
 
 "@istanbuljs/load-nyc-config@^1.0.0":
   version "1.1.0"
@@ -629,17 +651,22 @@ acorn-globals@^6.0.0:
     acorn "^7.1.1"
     acorn-walk "^7.1.1"
 
+acorn-jsx@^5.3.1:
+  version "5.3.1"
+  resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.1.tgz#fc8661e11b7ac1539c47dbfea2e72b3af34d267b"
+  integrity sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==
+
 acorn-walk@^7.1.1:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-7.2.0.tgz#0de889a601203909b0fbe07b8938dc21d2e967bc"
   integrity sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==
 
-acorn@^7.1.1:
+acorn@^7.1.1, acorn@^7.4.0:
   version "7.4.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.4.1.tgz#feaed255973d2e77555b83dbc08851a6c63520fa"
   integrity sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==
 
-ajv@^6.12.3:
+ajv@^6.10.0, ajv@^6.12.3, ajv@^6.12.4:
   version "6.12.6"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz#baf5a62e802b07d977034586f8c3baf5adf26df4"
   integrity sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==
@@ -649,12 +676,27 @@ ajv@^6.12.3:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
+ajv@^7.0.2:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-7.1.1.tgz#1e6b37a454021fa9941713f38b952fc1c8d32a84"
+  integrity sha512-ga/aqDYnUy/o7vbsRTFhhTsNeXiYb5JWDIcRIeZfwRNCefwjNTVYCGdGSUrEmiu3yDK3vFvNbgJxvrQW4JXrYQ==
+  dependencies:
+    fast-deep-equal "^3.1.1"
+    json-schema-traverse "^1.0.0"
+    require-from-string "^2.0.2"
+    uri-js "^4.2.2"
+
 ansi-align@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/ansi-align/-/ansi-align-3.0.0.tgz#b536b371cf687caaef236c18d3e21fe3797467cb"
   integrity sha512-ZpClVKqXN3RGBmKibdfWzqCY4lnjEuoNzU5T0oEFpfd/z5qJHVarukridD4juLO2FXMiwUQxr9WqQtaYa8XRYw==
   dependencies:
     string-width "^3.0.0"
+
+ansi-colors@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-4.1.1.tgz#cbb9ae256bf750af1eab344f229aa27fe94ba348"
+  integrity sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==
 
 ansi-escapes@^4.2.1:
   version "4.3.1"
@@ -751,6 +793,11 @@ assign-symbols@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/assign-symbols/-/assign-symbols-1.0.0.tgz#59667f41fadd4f20ccbc2bb96b8d4f7f78ec0367"
   integrity sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=
+
+astral-regex@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-2.0.0.tgz#483143c567aeed4785759c0865786dc77d7d2e31"
+  integrity sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==
 
 asynckit@^0.4.0:
   version "0.4.0"
@@ -1247,7 +1294,7 @@ cross-spawn@^6.0.0:
     shebang-command "^1.2.0"
     which "^1.2.9"
 
-cross-spawn@^7.0.0:
+cross-spawn@^7.0.0, cross-spawn@^7.0.2:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
   integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==
@@ -1308,7 +1355,7 @@ debug@^3.2.6:
   dependencies:
     ms "^2.1.1"
 
-debug@^4.1.0, debug@^4.1.1:
+debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.1.tgz#f0d229c505e0c6d8c49ac553d1b13dc183f6b2ee"
   integrity sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==
@@ -1342,7 +1389,7 @@ deep-extend@^0.6.0:
   resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.6.0.tgz#c4fa7c95404a17a9c3e8ca7e1537312b736330ac"
   integrity sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==
 
-deep-is@~0.1.3:
+deep-is@^0.1.3, deep-is@~0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
   integrity sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=
@@ -1408,6 +1455,13 @@ diff-sequences@^26.6.2:
   version "26.6.2"
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-26.6.2.tgz#48ba99157de1923412eed41db6b6d4aa9ca7c0b1"
   integrity sha512-Mv/TDa3nZ9sbc5soK+OoA74BsS3mL37yixCvUAQkiuA4Wz6YtwP/K47n2rv2ovzHZvoiQeA5FTQOschKkEwB0Q==
+
+doctrine@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-3.0.0.tgz#addebead72a6574db783639dc87a121773973961"
+  integrity sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==
+  dependencies:
+    esutils "^2.0.2"
 
 domexception@^2.0.1:
   version "2.0.1"
@@ -1478,6 +1532,13 @@ end-of-stream@^1.1.0:
   dependencies:
     once "^1.4.0"
 
+enquirer@^2.3.5:
+  version "2.3.6"
+  resolved "https://registry.yarnpkg.com/enquirer/-/enquirer-2.3.6.tgz#2a7fe5dd634a1e4125a975ec994ff5456dc3734d"
+  integrity sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==
+  dependencies:
+    ansi-colors "^4.1.1"
+
 error-ex@^1.3.1:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/error-ex/-/error-ex-1.3.2.tgz#b4ac40648107fdcdcfae242f428bea8a14d4f1bf"
@@ -1522,15 +1583,111 @@ escodegen@^1.14.1:
   optionalDependencies:
     source-map "~0.6.1"
 
+eslint-scope@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.1.1.tgz#e786e59a66cb92b3f6c1fb0d508aab174848f48c"
+  integrity sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==
+  dependencies:
+    esrecurse "^4.3.0"
+    estraverse "^4.1.1"
+
+eslint-utils@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-2.1.0.tgz#d2de5e03424e707dc10c74068ddedae708741b27"
+  integrity sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==
+  dependencies:
+    eslint-visitor-keys "^1.1.0"
+
+eslint-visitor-keys@^1.1.0, eslint-visitor-keys@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz#30ebd1ef7c2fdff01c3a4f151044af25fab0523e"
+  integrity sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==
+
+eslint-visitor-keys@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-2.0.0.tgz#21fdc8fbcd9c795cc0321f0563702095751511a8"
+  integrity sha512-QudtT6av5WXels9WjIM7qz1XD1cWGvX4gGXvp/zBn9nXG02D0utdU3Em2m/QjTnrsk6bBjmCygl3rmj118msQQ==
+
+eslint@^7.21.0:
+  version "7.21.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-7.21.0.tgz#4ecd5b8c5b44f5dedc9b8a110b01bbfeb15d1c83"
+  integrity sha512-W2aJbXpMNofUp0ztQaF40fveSsJBjlSCSWpy//gzfTvwC+USs/nceBrKmlJOiM8r1bLwP2EuYkCqArn/6QTIgg==
+  dependencies:
+    "@babel/code-frame" "7.12.11"
+    "@eslint/eslintrc" "^0.4.0"
+    ajv "^6.10.0"
+    chalk "^4.0.0"
+    cross-spawn "^7.0.2"
+    debug "^4.0.1"
+    doctrine "^3.0.0"
+    enquirer "^2.3.5"
+    eslint-scope "^5.1.1"
+    eslint-utils "^2.1.0"
+    eslint-visitor-keys "^2.0.0"
+    espree "^7.3.1"
+    esquery "^1.4.0"
+    esutils "^2.0.2"
+    file-entry-cache "^6.0.1"
+    functional-red-black-tree "^1.0.1"
+    glob-parent "^5.0.0"
+    globals "^12.1.0"
+    ignore "^4.0.6"
+    import-fresh "^3.0.0"
+    imurmurhash "^0.1.4"
+    is-glob "^4.0.0"
+    js-yaml "^3.13.1"
+    json-stable-stringify-without-jsonify "^1.0.1"
+    levn "^0.4.1"
+    lodash "^4.17.20"
+    minimatch "^3.0.4"
+    natural-compare "^1.4.0"
+    optionator "^0.9.1"
+    progress "^2.0.0"
+    regexpp "^3.1.0"
+    semver "^7.2.1"
+    strip-ansi "^6.0.0"
+    strip-json-comments "^3.1.0"
+    table "^6.0.4"
+    text-table "^0.2.0"
+    v8-compile-cache "^2.0.3"
+
+espree@^7.3.0, espree@^7.3.1:
+  version "7.3.1"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-7.3.1.tgz#f2df330b752c6f55019f8bd89b7660039c1bbbb6"
+  integrity sha512-v3JCNCE64umkFpmkFGqzVKsOT0tN1Zr+ueqLZfpV1Ob8e+CEgPWa+OxCoGH3tnhimMKIaBm4m/vaRpJ/krRz2g==
+  dependencies:
+    acorn "^7.4.0"
+    acorn-jsx "^5.3.1"
+    eslint-visitor-keys "^1.3.0"
+
 esprima@^4.0.0, esprima@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
   integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
 
-estraverse@^4.2.0:
+esquery@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.4.0.tgz#2148ffc38b82e8c7057dfed48425b3e61f0f24a5"
+  integrity sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==
+  dependencies:
+    estraverse "^5.1.0"
+
+esrecurse@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/esrecurse/-/esrecurse-4.3.0.tgz#7ad7964d679abb28bee72cec63758b1c5d2c9921"
+  integrity sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==
+  dependencies:
+    estraverse "^5.2.0"
+
+estraverse@^4.1.1, estraverse@^4.2.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.3.0.tgz#398ad3f3c5a24948be7725e83d11a7de28cdbd1d"
   integrity sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==
+
+estraverse@^5.1.0, estraverse@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-5.2.0.tgz#307df42547e6cc7324d3cf03c155d5cdb8c53880"
+  integrity sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==
 
 esutils@^2.0.2:
   version "2.0.3"
@@ -1695,7 +1852,7 @@ fast-json-stable-stringify@^2.0.0:
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
   integrity sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
 
-fast-levenshtein@~2.0.6:
+fast-levenshtein@^2.0.6, fast-levenshtein@~2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
@@ -1711,6 +1868,13 @@ fb-watchman@^2.0.0:
   integrity sha512-DkPJKQeY6kKwmuMretBhr7G6Vodr7bFwDYTXIkfG1gjvNpaxBTQV3PbXg6bR1c1UP4jPOX0jHUbbHANL9vRjVg==
   dependencies:
     bser "2.1.1"
+
+file-entry-cache@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/file-entry-cache/-/file-entry-cache-6.0.1.tgz#211b2dd9659cb0394b073e7323ac3c933d522027"
+  integrity sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==
+  dependencies:
+    flat-cache "^3.0.4"
 
 fill-range@^4.0.0:
   version "4.0.0"
@@ -1749,6 +1913,19 @@ find-up@^4.0.0, find-up@^4.1.0:
   dependencies:
     locate-path "^5.0.0"
     path-exists "^4.0.0"
+
+flat-cache@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-3.0.4.tgz#61b0338302b2fe9f957dcc32fc2a87f1c3048b11"
+  integrity sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==
+  dependencies:
+    flatted "^3.1.0"
+    rimraf "^3.0.2"
+
+flatted@^3.1.0:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.1.1.tgz#c4b489e80096d9df1dfc97c79871aea7c617c469"
+  integrity sha512-zAoAQiudy+r5SvnSw3KJy5os/oRJYHzrzja/tBDqrZtNhUw8bt6y8OBzMWcjWr+8liV8Eb6yOhw8WZ7VFZ5ZzA==
 
 for-in@^1.0.2:
   version "1.0.2"
@@ -1815,6 +1992,11 @@ function-bind@^1.1.1:
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
   integrity sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==
 
+functional-red-black-tree@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
+  integrity sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=
+
 gensync@^1.0.0-beta.2:
   version "1.0.0-beta.2"
   resolved "https://registry.yarnpkg.com/gensync/-/gensync-1.0.0-beta.2.tgz#32a6ee76c3d7f52d46b2b1ae5d93fea8580a25e0"
@@ -1856,7 +2038,7 @@ getpass@^0.1.1:
   dependencies:
     assert-plus "^1.0.0"
 
-glob-parent@~5.1.0:
+glob-parent@^5.0.0, glob-parent@~5.1.0:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.1.tgz#b6c1ef417c4e5663ea498f1c45afac6916bbc229"
   integrity sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==
@@ -1886,6 +2068,13 @@ globals@^11.1.0:
   version "11.12.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-11.12.0.tgz#ab8795338868a0babd8525758018c2a7eb95c42e"
   integrity sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==
+
+globals@^12.1.0:
+  version "12.4.0"
+  resolved "https://registry.yarnpkg.com/globals/-/globals-12.4.0.tgz#a18813576a41b00a24a97e7f815918c2e19925f8"
+  integrity sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==
+  dependencies:
+    type-fest "^0.8.1"
 
 got@^9.6.0:
   version "9.6.0"
@@ -2049,6 +2238,19 @@ ignore-by-default@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/ignore-by-default/-/ignore-by-default-1.0.1.tgz#48ca6d72f6c6a3af00a9ad4ae6876be3889e2b09"
   integrity sha1-SMptcvbGo68Aqa1K5odr44ieKwk=
+
+ignore@^4.0.6:
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
+  integrity sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
+
+import-fresh@^3.0.0, import-fresh@^3.2.1:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.3.0.tgz#37162c25fcb9ebaa2e6e53d5b4d88ce17d9e0c2b"
+  integrity sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==
+  dependencies:
+    parent-module "^1.0.0"
+    resolve-from "^4.0.0"
 
 import-lazy@^2.1.0:
   version "2.1.0"
@@ -2220,7 +2422,7 @@ is-generator-fn@^2.0.0:
   resolved "https://registry.yarnpkg.com/is-generator-fn/-/is-generator-fn-2.1.0.tgz#7d140adc389aaf3011a8f2a2a4cfa6faadffb118"
   integrity sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==
 
-is-glob@^4.0.1, is-glob@~4.0.1:
+is-glob@^4.0.0, is-glob@^4.0.1, is-glob@~4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.1.tgz#7567dbe9f2f5e2467bc77ab83c4a29482407a5dc"
   integrity sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==
@@ -2817,10 +3019,20 @@ json-schema-traverse@^0.4.1:
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz#69f6a87d9513ab8bb8fe63bdb0979c448e684660"
   integrity sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==
 
+json-schema-traverse@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz#ae7bcb3656ab77a73ba5c49bf654f38e6b6860e2"
+  integrity sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==
+
 json-schema@0.2.3:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/json-schema/-/json-schema-0.2.3.tgz#b480c892e59a2f05954ce727bd3f2a4e882f9e13"
   integrity sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=
+
+json-stable-stringify-without-jsonify@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
+  integrity sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=
 
 json-stringify-safe@~5.0.1:
   version "5.0.1"
@@ -2892,6 +3104,14 @@ leven@^3.1.0:
   resolved "https://registry.yarnpkg.com/leven/-/leven-3.1.0.tgz#77891de834064cccba82ae7842bb6b14a13ed7f2"
   integrity sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==
 
+levn@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/levn/-/levn-0.4.1.tgz#ae4562c007473b932a6200d403268dd2fffc6ade"
+  integrity sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==
+  dependencies:
+    prelude-ls "^1.2.1"
+    type-check "~0.4.0"
+
 levn@~0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/levn/-/levn-0.3.0.tgz#3b09924edf9f083c0490fdd4c0bc4421e04764ee"
@@ -2917,7 +3137,7 @@ lodash.sortby@^4.7.0:
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
   integrity sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=
 
-lodash@^4.17.19:
+lodash@^4.17.19, lodash@^4.17.20:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -3296,6 +3516,18 @@ optionator@^0.8.1:
     type-check "~0.3.2"
     word-wrap "~1.2.3"
 
+optionator@^0.9.1:
+  version "0.9.1"
+  resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.9.1.tgz#4f236a6373dae0566a6d43e1326674f50c291499"
+  integrity sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==
+  dependencies:
+    deep-is "^0.1.3"
+    fast-levenshtein "^2.0.6"
+    levn "^0.4.1"
+    prelude-ls "^1.2.1"
+    type-check "^0.4.0"
+    word-wrap "^1.2.3"
+
 p-cancelable@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/p-cancelable/-/p-cancelable-1.1.0.tgz#d078d15a3af409220c886f1d9a0ca2e441ab26cc"
@@ -3344,6 +3576,13 @@ packet-reader@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/packet-reader/-/packet-reader-1.0.0.tgz#9238e5480dedabacfe1fe3f2771063f164157d74"
   integrity sha512-HAKu/fG3HpHFO0AA8WE8q2g+gBJaZ9MG7fcKk+IJPLTGAD6Psw4443l+9DGRbOIh3/aXr7Phy0TjilYivJo5XQ==
+
+parent-module@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/parent-module/-/parent-module-1.0.1.tgz#691d2709e78c79fae3a156622452d00762caaaa2"
+  integrity sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==
+  dependencies:
+    callsites "^3.0.0"
 
 parse-json@^5.0.0:
   version "5.2.0"
@@ -3507,6 +3746,11 @@ postgres-interval@^1.1.0:
   dependencies:
     xtend "^4.0.0"
 
+prelude-ls@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"
+  integrity sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==
+
 prelude-ls@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
@@ -3526,6 +3770,11 @@ pretty-format@^26.6.2:
     ansi-regex "^5.0.0"
     ansi-styles "^4.0.0"
     react-is "^17.0.1"
+
+progress@^2.0.0:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
+  integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
 
 prompts@^2.0.1:
   version "2.4.0"
@@ -3688,6 +3937,11 @@ regex-not@^1.0.0, regex-not@^1.0.2:
     extend-shallow "^3.0.2"
     safe-regex "^1.1.0"
 
+regexpp@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-3.1.0.tgz#206d0ad0a5648cffbdb8ae46438f3dc51c9f78e2"
+  integrity sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==
+
 registry-auth-token@^4.0.0:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/registry-auth-token/-/registry-auth-token-4.2.1.tgz#6d7b4006441918972ccd5fedcd41dc322c79b250"
@@ -3764,6 +4018,11 @@ require-directory@^2.1.1:
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
   integrity sha1-jGStX9MNqxyXbiNE/+f3kqam30I=
 
+require-from-string@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-2.0.2.tgz#89a7fdd938261267318eafe14f9c32e598c36909"
+  integrity sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==
+
 require-main-filename@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-2.0.0.tgz#d0b329ecc7cc0f61649f62215be69af54aa8989b"
@@ -3775,6 +4034,11 @@ resolve-cwd@^3.0.0:
   integrity sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==
   dependencies:
     resolve-from "^5.0.0"
+
+resolve-from@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-4.0.0.tgz#4abcd852ad32dd7baabfe9b40e00a36db5f392e6"
+  integrity sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==
 
 resolve-from@^5.0.0:
   version "5.0.0"
@@ -3806,7 +4070,7 @@ ret@~0.1.10:
   resolved "https://registry.yarnpkg.com/ret/-/ret-0.1.15.tgz#b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc"
   integrity sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==
 
-rimraf@^3.0.0:
+rimraf@^3.0.0, rimraf@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
   integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
@@ -3879,7 +4143,7 @@ semver@^6.0.0, semver@^6.2.0, semver@^6.3.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
 
-semver@^7.3.2:
+semver@^7.2.1, semver@^7.3.2:
   version "7.3.4"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.4.tgz#27aaa7d2e4ca76452f98d3add093a72c943edc97"
   integrity sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==
@@ -3978,6 +4242,15 @@ slash@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-3.0.0.tgz#6539be870c165adbd5240220dbe361f1bc4d4634"
   integrity sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==
+
+slice-ansi@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-4.0.0.tgz#500e8dd0fd55b05815086255b3195adf2a45fe6b"
+  integrity sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==
+  dependencies:
+    ansi-styles "^4.0.0"
+    astral-regex "^2.0.0"
+    is-fullwidth-code-point "^3.0.0"
 
 snapdragon-node@^2.0.1:
   version "2.1.1"
@@ -4204,6 +4477,11 @@ strip-final-newline@^2.0.0:
   resolved "https://registry.yarnpkg.com/strip-final-newline/-/strip-final-newline-2.0.0.tgz#89b852fb2fcbe936f6f4b3187afb0a12c1ab58ad"
   integrity sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==
 
+strip-json-comments@^3.1.0, strip-json-comments@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
+  integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
+
 strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
@@ -4261,6 +4539,16 @@ symbol-tree@^3.2.4:
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.4.tgz#430637d248ba77e078883951fb9aa0eed7c63fa2"
   integrity sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==
 
+table@^6.0.4:
+  version "6.0.7"
+  resolved "https://registry.yarnpkg.com/table/-/table-6.0.7.tgz#e45897ffbcc1bcf9e8a87bf420f2c9e5a7a52a34"
+  integrity sha512-rxZevLGTUzWna/qBLObOe16kB2RTnnbhciwgPbMMlazz1yZGVEgnZK762xyVdVznhqxrfCeBMmMkgOOaPwjH7g==
+  dependencies:
+    ajv "^7.0.2"
+    lodash "^4.17.20"
+    slice-ansi "^4.0.0"
+    string-width "^4.2.0"
+
 term-size@^2.1.0:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/term-size/-/term-size-2.2.1.tgz#2a6a54840432c2fb6320fea0f415531e90189f54"
@@ -4282,6 +4570,11 @@ test-exclude@^6.0.0:
     "@istanbuljs/schema" "^0.1.2"
     glob "^7.1.4"
     minimatch "^3.0.4"
+
+text-table@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
+  integrity sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=
 
 throat@^5.0.0:
   version "5.0.0"
@@ -4382,6 +4675,13 @@ tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   version "0.14.5"
   resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-0.14.5.tgz#5ae68177f192d4456269d108afa93ff8743f4f64"
   integrity sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=
+
+type-check@^0.4.0, type-check@~0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/type-check/-/type-check-0.4.0.tgz#07b8203bfa7056c0657050e3ccd2c37730bab8f1"
+  integrity sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==
+  dependencies:
+    prelude-ls "^1.2.1"
 
 type-check@~0.3.2:
   version "0.3.2"
@@ -4530,6 +4830,11 @@ uuid@^8.3.0:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
 
+v8-compile-cache@^2.0.3:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.2.0.tgz#9471efa3ef9128d2f7c6a7ca39c4dd6b5055b132"
+  integrity sha512-gTpR5XQNKFwOd4clxfnhaqvfqMpqEwr4tOtCyz4MtYZX2JYhfr1JvBFKdS+7K/9rfpZR3VLX+YWBbKoxCgS43Q==
+
 v8-to-istanbul@^7.0.0:
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/v8-to-istanbul/-/v8-to-istanbul-7.1.0.tgz#5b95cef45c0f83217ec79f8fc7ee1c8b486aee07"
@@ -4639,7 +4944,7 @@ widest-line@^3.1.0:
   dependencies:
     string-width "^4.0.0"
 
-word-wrap@~1.2.3:
+word-wrap@^1.2.3, word-wrap@~1.2.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.3.tgz#610636f6b1f703891bd34771ccb17fb93b47079c"
   integrity sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==


### PR DESCRIPTION
- Reformatted JS
- Redis client init located in /shared/init-redis-client.js
- Constants moved to /shared/constants.js
- prod-tasks.js script has a process.exit timeout
- Reduced number of third party API calls by storing data in Redis
  - Upon manufacturer availability fetch the manufacturer name is added to Redis hash manufacturer-list
  - As product data is fetched, each manufacturer identified checks whether a fetch has been made on that manufacturer, and gets data from Redis instead of fetch if true
    - Manufacturer API data is independent of a product. Previously each product fetched manufacturer data x6, which led to the same manufacturer data being fetched 3 times with no changes, a total of 18 times
    - Now each manufacturer data is fetched once, a total of 6 times
- Added a Redis subscriber to index.js
  - Init in /shared/subscriber-init.js, used by app/index.js and ./jobs/prod-task.js
  - Subscribes to keyspace keyevent set notifications
  - When a manufacturer is added to the manufacturer-list hash, add it to the update-ready hash
  - When all manufacturers are added to the update-ready hash, then call updateAvailability for each product
    - Previously this was called for each product and manufacturer (18 times), and is now called only 3 times total 